### PR TITLE
added a new rule to .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "space-infix-ops": "error",
     "comma-dangle": 0,
     "max-len": 0,
+    "import/namespace": 0,
     "import/extensions": 0,
     "no-underscore-dangle": 0,
     "consistent-return": 0,


### PR DESCRIPTION
added rule "import/namespace": 0 to fix the vite error.